### PR TITLE
update to 3.5.2

### DIFF
--- a/com.teamspeak.TeamSpeak.appdata.xml
+++ b/com.teamspeak.TeamSpeak.appdata.xml
@@ -27,6 +27,7 @@
     <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
   <releases>
+    <release date="2020-04-02" version="3.5.2"/>
     <release date="2020-03-23" version="3.5.1"/>
     <release date="2020-03-19" version="3.5.0"/>
     <release date="2019-08-26" version="3.3.2"/>

--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -34,9 +34,9 @@ modules:
         only-arches:
           - i386
         filename: TeamSpeak3-Client.run
-        url: https://files.teamspeak-services.com/releases/client/3.5.1/TeamSpeak3-Client-linux_x86-3.5.1.run
-        sha256: fa2000d270cb8da34753cbe746cf41fe13428b7ea24a2c626c697e5a2b662d53
-        size: 95934901
+        url: https://files.teamspeak-services.com/releases/client/3.5.2/TeamSpeak3-Client-linux_x86-3.5.2.run
+        sha256: 209375141ea0d0fc1d6dc7612cb621ba0df946e033a3b1140f3e8a5c8938d566
+        size: 95930692
         x-checker-data:
           type: html
           url: https://teamspeak.com/en/downloads/
@@ -46,9 +46,9 @@ modules:
         only-arches:
           - x86_64
         filename: TeamSpeak3-Client.run
-        url: https://files.teamspeak-services.com/releases/client/3.5.1/TeamSpeak3-Client-linux_amd64-3.5.1.run
-        sha256: e5eda184ac64459d0e6f61c64aade004501dcfc0c3cc05f0f3ddb34864bbb15f
-        size: 97443497
+        url: https://files.teamspeak-services.com/releases/client/3.5.2/TeamSpeak3-Client-linux_amd64-3.5.2.run
+        sha256: d739fa78b41ef7b1423771ca237804981ffc7f14c4e620769cfa3fbc538aece8
+        size: 97442376
         x-checker-data:
           type: html
           url: https://teamspeak.com/en/downloads/


### PR DESCRIPTION
Teamspeak removed 3.5.1 from their servers and therefore the installation is currently failing. This pull updates to the newest version released yersterday.