### PR TITLE
Fix x-checker-data

### DIFF
--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -39,8 +39,8 @@ modules:
         size: 95930692
         x-checker-data:
           type: html
-          url: https://teamspeak.com/en/downloads/
-          version-pattern: https://files.teamspeak-services.com/releases/client/([\d\.]+)/TeamSpeak3-Client-linux_x86-([\d\.]+).run
+          url: https://files.teamspeak-services.com/releases/client/
+          version-pattern: (\d+\.\d+\.\d+)
           url-template: https://files.teamspeak-services.com/releases/client/$version/TeamSpeak3-Client-linux_x86-$version.run
       - type: extra-data
         only-arches:
@@ -51,8 +51,8 @@ modules:
         size: 97442376
         x-checker-data:
           type: html
-          url: https://teamspeak.com/en/downloads/
-          version-pattern: https://files.teamspeak-services.com/releases/client/([\d\.]+)/TeamSpeak3-Client-linux_amd64-([\d\.]+).run
+          url: https://files.teamspeak-services.com/releases/client/
+          version-pattern: (\d+\.\d+\.\d+)
           url-template: https://files.teamspeak-services.com/releases/client/$version/TeamSpeak3-Client-linux_amd64-$version.run
       - type: script
         dest-filename: apply_extra


### PR DESCRIPTION
Currently it always fails, see for example: https://github.com/flathub/flathub/runs/668755261#step:3:3512

Tested it locally and it seems to work:
```
CHANGE SOON: TeamSpeak3-Client.run
 Has a new version:
  URL:     https://files.teamspeak-services.com/releases/client/3.5.3/TeamSpeak3-Client-linux_x86-3.5.3.run
  SHA256:  86a6513d36b9d454171278b03229a290f3548343a604f2fdf31db17c6584275a
  Size:    95939656
  Version: 3.5.3

CHANGE SOON: TeamSpeak3-Client.run
 Has a new version:
  URL:     https://files.teamspeak-services.com/releases/client/3.5.3/TeamSpeak3-Client-linux_amd64-3.5.3.run
  SHA256:  ca9cdb5409042c86f2981dd32e046b7f8de4aab6a8333edc7e1fb83eb3d8e93a
  Size:    97454216
  Version: 3.5.3
``` 
