### PR TITLE
Use newer freedesktop platform 23.08

### DIFF
--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -2,7 +2,7 @@ app-id: com.teamspeak.TeamSpeak
 tags:
   - proprietary
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: teamspeak
 finish-args:


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0). It includes updated libraries, but probably won't affect TeamSpeak. Compiled and tested by me.