### PR TITLE
Update runtime to Gnome 47

### DIFF
--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -2,7 +2,7 @@ app-id: com.teamspeak.TeamSpeak
 tags:
   - proprietary
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: teamspeak5
 finish-args:


### PR DESCRIPTION
flatpak CLI says
```
Info: runtime org.gnome.Platform branch 45 is end-of-life, with reason:
   The GNOME 45 runtime is no longer supported as of September 18, 2024. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   com.teamspeak.TeamSpeak
```