### PR TITLE
Switch to Freedesktop runtime

### DIFF
--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -1,9 +1,9 @@
 app-id: com.teamspeak.TeamSpeak
 tags:
   - proprietary
-runtime: org.gnome.Platform
-runtime-version: '47'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
 command: teamspeak5
 finish-args:
   - --socket=x11


### PR DESCRIPTION
This application works perfectly fine with runtime `org.freedesktop.Platform`. this pull request reduces storage space usage for users who don't use other Gnome/Adwaita-based application.