### PR TITLE
Remove version number from desktop file

### DIFF
--- a/com.teamspeak.TeamSpeak.desktop
+++ b/com.teamspeak.TeamSpeak.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=TeamSpeak5
-Comment=TeamSpeak5 VoIP application
-Exec=teamspeak5 %u
+Name=TeamSpeak
+Comment=TeamSpeak VoIP application
+Exec=teamspeak %u
 MimeType=x-scheme-handler/ts3server;
 Terminal=false
 Type=Application


### PR DESCRIPTION
This package currently can't be launched from application launcher due to wrong `Exec` entry.