### PR TITLE
Remove unnecessary device argument from TeamSpeak config (#91)

### DIFF
--- a/com.teamspeak.TeamSpeak.yaml
+++ b/com.teamspeak.TeamSpeak.yaml
@@ -9,7 +9,6 @@ finish-args:
   - --socket=wayland
   - --socket=x11
   - --socket=pulseaudio
-  - --device=dri
   - --device=all
   - --share=network
   - --share=ipc


### PR DESCRIPTION
There seem to be some more stones on the way to the update, see #91  xd